### PR TITLE
feat: add exercise history modal

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -847,6 +847,7 @@ body {
 .col-exercise {
   font-weight: 600;
   color: var(--text-primary);
+  cursor: pointer;
 }
 
 .col-equipment {
@@ -891,6 +892,46 @@ body {
   gap: 20px;
   justify-content: center;
   margin-top: 48px;
+}
+
+/* History Modal */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: var(--bg-card);
+  padding: 24px;
+  border-radius: 8px;
+  max-height: 80vh;
+  overflow-y: auto;
+  box-shadow: var(--shadow-glow);
+}
+
+.history-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 16px;
+}
+
+.history-table th,
+.history-table td {
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border-medium);
+  text-align: left;
+}
+
+.modal-close {
+  margin-top: 16px;
 }
 
 /* Create Split Form - Gladiator Style */


### PR DESCRIPTION
## Summary
- show full exercise history in modal popup when clicking an exercise
- track complete per-exercise history from sessions API
- add styles for modal overlay and table

## Testing
- `pytest`
- `cd frontend && CI=true yarn test --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689127adf3f08328bb186779ae4b2ef2