### PR TITLE
Fix exercise history rep display

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -98,6 +98,7 @@ class Set(BaseModel):
 class WorkoutExercise(BaseModel):
     exercise_id: str
     exercise_name: str
+    rep_range: Optional[str] = None
     sets: List[Set] = []
     completed_count: int = 0
     target_completions: int = 3

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -665,6 +665,13 @@ const ExerciseArchiveView = ({ exercises, muscleGroups, setCurrentView }) => {
   const [showHistoryModal, setShowHistoryModal] = useState(false);
   const [selectedExercise, setSelectedExercise] = useState(null);
 
+  // Rep range options mirror those used in the workout view
+  const repRangeOptions = [
+    { value: '6-10', label: '6-10 reps', min: 6, max: 10, default: 8 },
+    { value: '8-12', label: '8-12 reps', min: 8, max: 12, default: 10 },
+    { value: '10-14', label: '10-14 reps', min: 10, max: 14, default: 12 }
+  ];
+
   useEffect(() => {
     setExerciseOrder(exercises.map(ex => ex.id));
     fetchExerciseHistory();
@@ -750,13 +757,15 @@ const ExerciseArchiveView = ({ exercises, muscleGroups, setCurrentView }) => {
 
     const latest = historyEntries[0];
     const lastSet = latest.sets[latest.sets.length - 1];
+    const repRangeDefault = repRangeOptions.find(r => r.value === latest.rep_range)?.default;
+    const reps = (lastSet.reps && lastSet.reps > 0) ? lastSet.reps : (repRangeDefault ?? 0);
     const date = new Date(latest.date).toLocaleDateString();
 
     return (
       <div className="gladiator-history">
         <div className="history-date">📅 {date}</div>
         <div className="history-details">
-          ⚖️ {lastSet.weight}lbs × {lastSet.reps} reps
+          ⚖️ {lastSet.weight}lbs × {reps} reps
         </div>
         <div className="history-completions">
           🏆 {latest.completed_count} victories


### PR DESCRIPTION
## Summary
- Persist selected rep range in workout sessions
- Derive exercise history reps from the stored rep range when set data is missing

## Testing
- `npm run test:backend`
- `CI=true npm run test:frontend` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68912e7858f0832896a90d468b533b64